### PR TITLE
Fix import for PySide6

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import List
 
 import requests
-from pyside6.QtWidgets import (
+from PySide6.QtWidgets import (
     QApplication, QMainWindow, QWidget, QLabel, QPushButton,
     QVBoxLayout, QHBoxLayout, QRadioButton, QComboBox, QLineEdit
 )


### PR DESCRIPTION
## Summary
- update PySide6 import to use correct casing

## Testing
- `python app.py` (fails: No module named 'requests')